### PR TITLE
added using title parameter as email subject

### DIFF
--- a/android/src/main/java/com/twwm/share_files_and_screenshot_widgets/ShareFilesAndScreenshotWidgetsPlugin.java
+++ b/android/src/main/java/com/twwm/share_files_and_screenshot_widgets/ShareFilesAndScreenshotWidgetsPlugin.java
@@ -94,6 +94,8 @@ public class ShareFilesAndScreenshotWidgetsPlugin implements FlutterPlugin, Acti
         String fileProviderAuthority = activeContext.getPackageName() + PROVIDER_AUTH_EXT;
         Uri contentUri = FileProvider.getUriForFile(activeContext, fileProviderAuthority, file);
         shareIntent.putExtra(Intent.EXTRA_STREAM, contentUri);
+        // add email subject using title parameter
+        shareIntent.putExtra(Intent.EXTRA_SUBJECT,title);
         // add optional text
         if (!text.isEmpty()) shareIntent.putExtra(Intent.EXTRA_TEXT, text);
 


### PR DESCRIPTION
As mentioned in https://github.com/JayTWWM/Share-Files-And-Screenshot-Widgets-Flutter/issues/21,
sharing emails _**do not**_ have a subject attached, even though the `title` parameter from `.shareFile()`  can be used for that purpose.

this commit adds using the `title` parameter passed to `.shareFile()` as the email's subject, as an INTENT_EXTRA_SUBJECT.